### PR TITLE
Add support for date-time format

### DIFF
--- a/src/FluentSchema.test.js
+++ b/src/FluentSchema.test.js
@@ -526,7 +526,7 @@ describe('FluentSchema', () => {
           })
         })
         describe('format', () => {
-          it('valid', () => {
+          it('valid FORMATS.DATE', () => {
             const prop = 'prop'
             expect(
               FluentSchema()
@@ -540,6 +540,24 @@ describe('FluentSchema', () => {
                 prop: {
                   type: 'string',
                   format: FORMATS.DATE,
+                },
+              },
+              type: 'object',
+            })
+          })
+          it('valid FORMATS.DATE_TIME', () => {
+            expect(
+              FluentSchema()
+                .prop('prop')
+                .asString()
+                .format(FORMATS.DATE_TIME)
+                .valueOf()
+            ).toEqual({
+              $schema: 'http://json-schema.org/draft-07/schema#',
+              properties: {
+                prop: {
+                  type: 'string',
+                  format: 'date-time',
                 },
               },
               type: 'object',

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,6 +53,7 @@ const URI_REFERENCE = 'uri-reference'
 const URI = 'uri'
 const TIME = 'time'
 const DATE = 'date'
+const DATE_TIME = 'date-time'
 
 const FORMATS = {
   RELATIVE_JSON_POINTER,
@@ -69,6 +70,7 @@ const FORMATS = {
   URI,
   TIME,
   DATE,
+  DATE_TIME,
 }
 
 // TODO LS looking for a better name


### PR DESCRIPTION
Hi, it looks like that the `date-time` format is missing in the `FORMATS` array, so I have added it since it is [part of the specification](https://json-schema.org/latest/json-schema-validation.html#rfc.section.7.3.1) and it is [supported by Ajv](https://ajv.js.org/#formats).