### PR TITLE
Support required in nested prop (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,20 @@ const schema = FluentSchema()
     FluentSchema()
       .asString()
       .format(FORMATS.EMAIL)
+      .required()
   )
-  .required()
   .prop(
     'password',
     FluentSchema()
       .asString()
       .minLength(8)
   )
-  .required()
   .prop(
     'role',
     FluentSchema()
       .enum(['ADMIN', 'USER'])
       .default('USER')
+      .required()
   )
   .definition(
     'address',

--- a/docs/API.md
+++ b/docs/API.md
@@ -48,7 +48,7 @@ There are no restrictions placed on the values within the array.</p>
 <p><a href="reference">https://json-schema.org/latest/json-schema-validation.html#rfc.section.10.2</a></p>
 </dd>
 <dt><a href="#required">required()</a> ⇒ <code><a href="#FluentSchema">FluentSchema</a></code></dt>
-<dd><p>Required&#39; has to be chained to a property:
+<dd><p>Required has to be chained to a property:
 Examples:</p>
 <ul>
 <li>FluentSchema().prop(&#39;prop&#39;).required()</li>
@@ -375,7 +375,7 @@ There are no restrictions placed on the value of this keyword.
 
 ## required() ⇒ [<code>FluentSchema</code>](#FluentSchema)
 
-Required' has to be chained to a property:
+Required has to be chained to a property:
 Examples:
 
 - FluentSchema().prop('prop').required()

--- a/src/FluentSchema.integration.test.js
+++ b/src/FluentSchema.integration.test.js
@@ -187,8 +187,12 @@ describe('FluentSchema', () => {
       )
       .prop('username')
       .required()
-      .prop('password')
-      .required()
+      .prop(
+        'password',
+        FluentSchema()
+          .asString()
+          .required()
+      )
       .prop('address')
       .ref('#address')
       .required()
@@ -196,10 +200,10 @@ describe('FluentSchema', () => {
         'role',
         FluentSchema()
           .id('http://foo.com/role')
+          .required()
           .prop('name')
           .prop('permissions')
       )
-      .required()
       .prop('age')
       .asNumber()
       .valueOf()

--- a/src/FluentSchema.test.js
+++ b/src/FluentSchema.test.js
@@ -380,14 +380,74 @@ describe('FluentSchema', () => {
         ).toEqual([prop])
       })
 
-      it('invalid', () => {
-        expect(() => {
-          FluentSchema()
-            .asString()
-            .required()
-        }).toThrow(
-          "'required' has to be chained to a prop: \nExamples: \n- FluentSchema().prop('prop').required() \n- FluentSchema().prop('prop', FluentSchema().asNumber()).required()"
-        )
+      it('nested', () => {
+        const prop = 'foo'
+        const schema = FluentSchema()
+          .prop(
+            prop,
+            FluentSchema()
+              .asNumber()
+              .required()
+          )
+          .valueOf()
+        expect(schema.required).toEqual([prop])
+        expect(schema.properties[prop]).toEqual({ type: 'number' })
+      })
+
+      it('deep nested', () => {
+        const prop = 'foo'
+        const schema = FluentSchema()
+          .prop(
+            prop,
+            FluentSchema()
+              .required()
+              .prop('bar')
+              .required()
+          )
+          .valueOf()
+        expect(schema).toEqual({
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          properties: {
+            foo: {
+              properties: { bar: { type: 'string' } },
+              required: ['bar'],
+              type: 'object',
+            },
+          },
+          required: ['foo'],
+          type: 'object',
+        })
+      })
+
+      it('multiple deep nested', () => {
+        const schema = FluentSchema()
+          .prop(
+            'foo',
+            FluentSchema()
+              .required()
+              .prop('bar')
+              .required()
+          )
+          .prop(
+            'prop',
+            FluentSchema()
+              .asString()
+              .required()
+          )
+          .valueOf()
+        expect(schema).toEqual({
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          properties: {
+            foo: {
+              properties: { bar: { type: 'string' } },
+              required: ['bar'],
+              type: 'object',
+            },
+            prop: { type: 'string' },
+          },
+          required: ['foo', 'prop'],
+          type: 'object',
+        })
       })
     })
 

--- a/src/example.js
+++ b/src/example.js
@@ -11,15 +11,15 @@ const userSchema = FluentSchema()
     FluentSchema()
       .asString()
       .format(FORMATS.EMAIL)
+      .required()
   )
-  .required()
   .prop(
     'password',
     FluentSchema()
       .asString()
       .minLength(8)
+      .required()
   )
-  .required()
   .prop(
     'role',
     FluentSchema()

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,6 +39,8 @@ const flat = array =>
     }
   }, {})
 
+const REQUIRED = Symbol('required')
+
 const RELATIVE_JSON_POINTER = 'relative-json-pointer'
 const JSON_POINTER = 'json-pointer'
 const UUID = 'uuid'
@@ -96,13 +98,47 @@ const patchIdsWithParentId = ({ schema, generateIds, parentId }) => {
   }
 }
 
+const appendRequired = ({
+  attributes: { name, required, ...attributes },
+  schema,
+}) => {
+  const { schemaRequired, attributeRequired } = (required || []).reduce(
+    (memo, item) => {
+      return item === REQUIRED
+        ? {
+            ...memo,
+            // append prop name to the schema.required
+            schemaRequired: [...memo.schemaRequired, name],
+          }
+        : {
+            ...memo,
+            // propagate required attributes
+            attributeRequired: [...memo.attributeRequired, item],
+          }
+    },
+    { schemaRequired: [], attributeRequired: [] }
+  )
+
+  const schemaPatched = {
+    ...schema,
+    required: [...schema.required, ...schemaRequired],
+  }
+  const attributesPatched = {
+    ...attributes,
+    required: attributeRequired,
+  }
+  return [schemaPatched, attributesPatched]
+}
+
 module.exports = {
   isFluentSchema,
   hasCombiningKeywords,
   last,
   flat,
   omit,
+  REQUIRED,
   deepOmit,
   patchIdsWithParentId,
+  appendRequired,
   FORMATS,
 }


### PR DESCRIPTION
It works but the implementation is quite fragile. 
 
```js
const schema = FluentSchema()
  .prop('foo', FluentSchema().asString().required())
```
The main issue is that `required` has to be added to the parent schema. 

```json
 {
      "$schema": "http://json-schema.org/draft-07/schema#",
      "type": "object",
      "properties": {
        "foo": {
          "type": "string"
        }
      },
      "required": [
        "foo"
      ]
    }

```

So I need to mark a prop as required. Then I remove the required from the prop and I add it to the parent. 

I will think a bit more about how to do in a better way. Feedback welcome