### PR TITLE
Remove type string as default value when a prop is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ A fluent API to generate JSON schemas (draft-07) for Node.js and browser.
 
 [![view on npm](https://img.shields.io/npm/v/fluent-schema.svg)](https://www.npmjs.org/package/fluent-schema)
 [![Build Status](https://travis-ci.com/fastify/fluent-schema.svg?branch=master)](https://travis-ci.com/fastify/fluent-schema?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/fastify/fluent-schema/badge.svg?branch=master)](https://coveralls.io/github/fastify/fluent-schema?branch=master)
 
 ## Features
 
@@ -14,6 +13,7 @@ A fluent API to generate JSON schemas (draft-07) for Node.js and browser.
 - Javascript constants can be used in the JSON schema (e.g. _enum_, _const_, _default_ ) avoiding discrepancies between model and schema
 - Typescript definitions
 - Zero dependencies
+- Coverage 99%
 
 ## Install
 
@@ -27,6 +27,12 @@ or
 
 ```javascript
 const S = require('fluent-schema')
+
+const ROLES = {
+  ADMIN: 'ADMIN',
+  USER: 'USER',
+}
+
 const schema = S.object()
   .id('http://foo/user')
   .title('My First Fluent JSON Schema')
@@ -43,23 +49,24 @@ const schema = S.object()
       .minLength(8)
       .required()
   )
-  .prop('role', S.enum(['ADMIN', 'USER']).default('USER'))
+  .prop(
+    'role',
+    S.string()
+      .enum(Object.values(ROLES))
+      .default(ROLES.USER)
+  )
   .definition(
     'address',
     S.object()
       .id('#address')
-      .prop('line1')
-      .required()
-      .prop('line2')
-      .prop('country')
-      .required()
-      .prop('city')
-      .required()
-      .prop('zipcode')
-      .required()
+      .prop('line1', S.string())
+      .prop('line2', S.string())
+      .prop('country', S.string())
+      .prop('city', S.string())
+      .prop('zipcode', S.string())
+      .required(['line1', 'country', 'city', 'zipcode'])
   )
-  .prop('address')
-  .ref('#address')
+  .prop('address', S.ref('#address'))
 
 console.log(JSON.stringify(schema.valueOf(), undefined, 2))
 ```

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "ajv": "^6.5.5",
     "husky": "^1.1.3",
-    "jest": "^23.6.0",
+    "jest": "^24.3.1",
     "jsdoc-to-markdown": "^4.0.1",
     "lint-staged": "^8.0.4",
     "prettier": "^1.14.3",

--- a/src/BaseSchema.test.js
+++ b/src/BaseSchema.test.js
@@ -146,8 +146,8 @@ describe('BaseSchema', () => {
         it('nested', () => {
           expect(
             S.object()
-              .prop('foo')
-              .prop('bar', S.required())
+              .prop('foo', S.string())
+              .prop('bar', S.string().required())
               .required(['foo'])
               .valueOf()
           ).toEqual({

--- a/src/FluentSchema.integration.test.js
+++ b/src/FluentSchema.integration.test.js
@@ -16,8 +16,8 @@ describe('S', () => {
   describe('basic', () => {
     const ajv = new Ajv()
     const schema = S.object()
-      .prop('username')
-      .prop('password')
+      .prop('username', S.string())
+      .prop('password', S.string())
       .valueOf()
     const validate = ajv.compile(schema)
 
@@ -54,7 +54,7 @@ describe('S', () => {
       .ifThen(
         S.object().prop('prop', S.string().maxLength(5)),
         S.object()
-          .prop('extraProp')
+          .prop('extraProp', S.string())
           .required()
       )
       .valueOf()
@@ -94,10 +94,10 @@ describe('S', () => {
       .ifThenElse(
         S.object().prop('ifProp', S.string().enum([VALUES[0]])),
         S.object()
-          .prop('thenProp')
+          .prop('thenProp', S.string())
           .required(),
         S.object()
-          .prop('elseProp')
+          .prop('elseProp', S.string())
           .required()
       )
       .valueOf()
@@ -136,17 +136,16 @@ describe('S', () => {
         'address',
         S.object()
           .id('#/definitions/address')
-          .prop('street_address')
+          .prop('street_address', S.string())
           .required()
-          .prop('city')
+          .prop('city', S.string())
           .required()
-          .prop('state')
-          .required()
+          .prop('state', S.string().required())
       )
       .allOf([
         S.ref('#/definitions/address'),
         S.object()
-          .prop('type')
+          .prop('type', S.string())
           .enum(['residential', 'business']),
       ])
       .valueOf()
@@ -235,18 +234,18 @@ describe('S', () => {
           .default(false)
           .required()
       )
-      .prop('thenFooA')
-      .prop('thenFooB')
+      .prop('thenFooA', S.string())
+      .prop('thenFooB', S.string())
       .allOf([
         S.ifThen(
           S.object()
-            .prop('foo')
+            .prop('foo', S.string())
             .enum(['foo']),
           S.required(['thenFooA', 'thenFooB'])
         ),
         S.ifThen(
           S.object()
-            .prop('bar')
+            .prop('bar', S.string())
             .enum(['BAR']),
           S.required(['thenBarA', 'thenBarB'])
         ),
@@ -310,11 +309,11 @@ describe('S', () => {
         'address',
         S.object()
           .id('#address')
-          .prop('country')
-          .prop('city')
-          .prop('zipcode')
+          .prop('country', S.string())
+          .prop('city', S.string())
+          .prop('zipcode', S.string())
       )
-      .prop('username')
+      .prop('username', S.string())
       .required()
       .prop('password', S.string().required())
       .prop('address', S.object().ref('#address'))
@@ -325,7 +324,7 @@ describe('S', () => {
         S.object()
           .id('http://foo.com/role')
           .required()
-          .prop('name')
+          .prop('name', S.string())
           .prop('permissions')
       )
       .prop('age', S.number())
@@ -416,7 +415,7 @@ describe('S', () => {
                   .description('The unique identifier for a product')
                   .required()
               )
-              .prop('name')
+              .prop('name', S.string())
               .required()
               .prop(
                 'price',

--- a/src/FluentSchema.test.js
+++ b/src/FluentSchema.test.js
@@ -19,7 +19,7 @@ describe('S', () => {
           expect(
             S.withOptions({ generateIds: true })
               .object()
-              .prop('prop')
+              .prop('prop', S.string())
               .valueOf()
           ).toEqual({
             $schema: 'http://json-schema.org/draft-07/schema#',
@@ -31,7 +31,7 @@ describe('S', () => {
         it('false', () => {
           expect(
             S.object()
-              .prop('prop')
+              .prop('prop', S.string())
               .valueOf()
           ).toEqual({
             $schema: 'http://json-schema.org/draft-07/schema#',
@@ -48,7 +48,7 @@ describe('S', () => {
                 .prop(
                   'foo',
                   S.object()
-                    .prop('bar')
+                    .prop('bar', S.string())
                     .required()
                 )
                 .valueOf()
@@ -107,8 +107,8 @@ describe('S', () => {
               .definition(
                 'entity',
                 S.object()
-                  .prop('foo')
-                  .prop('bar')
+                  .prop('foo', S.string())
+                  .prop('bar', S.string())
               )
               .prop('prop')
               .ref('entity')
@@ -146,7 +146,7 @@ describe('S', () => {
                 'entity',
                 S.object()
                   .id('myCustomId')
-                  .prop('foo')
+                  .prop('foo', S.string())
               )
               .prop('prop')
               .ref('entity')
@@ -254,13 +254,13 @@ describe('S', () => {
         'address',
         S.object()
           .id('#address')
-          .prop('country')
-          .prop('city')
-          .prop('zipcode')
+          .prop('country', S.string())
+          .prop('city', S.string())
+          .prop('zipcode', S.string())
       )
-      .prop('username')
+      .prop('username', S.string())
       .required()
-      .prop('password')
+      .prop('password', S.string())
       .required()
       .prop('address', S.ref('#address'))
 
@@ -269,8 +269,8 @@ describe('S', () => {
         'role',
         S.object()
           .id('http://foo.com/role')
-          .prop('name')
-          .prop('permissions')
+          .prop('name', S.string())
+          .prop('permissions', S.string())
       )
       .required()
       .prop('age', S.number())

--- a/src/ObjectSchema.js
+++ b/src/ObjectSchema.js
@@ -215,7 +215,7 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
 
       const type = hasCombiningKeywords(attributes)
         ? undefined
-        : attributes.type || 'string'
+        : attributes.type
 
       const $ref = attributes.$ref
 

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -19,7 +19,7 @@ describe('ObjectSchema', () => {
         it('true', () => {
           expect(
             ObjectSchema({ generateIds: true })
-              .prop('prop')
+              .prop('prop', S.string())
               .valueOf()
           ).toEqual({
             properties: { prop: { $id: '#properties/prop', type: 'string' } },
@@ -33,7 +33,7 @@ describe('ObjectSchema', () => {
               .prop('prop')
               .valueOf()
           ).toEqual({
-            properties: { prop: { type: 'string' } },
+            properties: { prop: {} },
             type: 'object',
           })
         })
@@ -50,14 +50,12 @@ describe('ObjectSchema', () => {
                 )
                 .valueOf()
             ).toEqual({
-              // $schema: 'http://json-schema.org/draft-07/schema#',
               properties: {
                 foo: {
                   $id: '#properties/foo',
                   properties: {
                     bar: {
                       $id: '#properties/foo/properties/bar',
-                      type: 'string',
                     },
                   },
                   required: ['bar'],
@@ -74,7 +72,7 @@ describe('ObjectSchema', () => {
                 .prop(
                   'foo',
                   ObjectSchema()
-                    .prop('bar', S.string().id(id))
+                    .prop('bar', S.id(id))
                     .required()
                 )
                 .valueOf()
@@ -82,7 +80,7 @@ describe('ObjectSchema', () => {
               properties: {
                 foo: {
                   properties: {
-                    bar: { $id: 'myId', type: 'string' },
+                    bar: { $id: 'myId' },
                   },
                   required: ['bar'],
                   type: 'object',
@@ -111,12 +109,8 @@ describe('ObjectSchema', () => {
               entity: {
                 $id: '#definitions/entity',
                 properties: {
-                  bar: {
-                    type: 'string',
-                  },
-                  foo: {
-                    type: 'string',
-                  },
+                  bar: {},
+                  foo: {},
                 },
                 type: 'object',
               },
@@ -146,7 +140,7 @@ describe('ObjectSchema', () => {
               entity: {
                 $id: 'myCustomId',
                 properties: {
-                  foo: { type: 'string' },
+                  foo: {},
                 },
                 type: 'object',
               },
@@ -222,7 +216,6 @@ describe('ObjectSchema', () => {
             .id(id)
             .valueOf().properties[prop]
         ).toEqual({
-          type: 'string',
           $id: id,
         })
       })
@@ -256,10 +249,10 @@ describe('ObjectSchema', () => {
     })
 
     describe('properties', () => {
-      it('with type string', () => {
+      it('string', () => {
         expect(
           ObjectSchema()
-            .prop('prop')
+            .prop('prop', S.string())
             .valueOf().properties
         ).toEqual({
           prop: {
@@ -275,9 +268,7 @@ describe('ObjectSchema', () => {
               .prop('foo', ObjectSchema().prop('bar'))
               .valueOf().properties.foo.properties
           ).toEqual({
-            bar: {
-              type: 'string',
-            },
+            bar: {},
           })
         })
 
@@ -385,7 +376,7 @@ describe('ObjectSchema', () => {
             .valueOf()
         ).toEqual({
           patternProperties: { '^fo.*$': { type: 'string' } },
-          properties: { foo: { type: 'string' } },
+          properties: { foo: {} },
           type: 'object',
         })
       })
@@ -417,8 +408,8 @@ describe('ObjectSchema', () => {
         ).toEqual({
           dependencies: { foo: ['bar'] },
           properties: {
-            bar: { type: 'string' },
-            foo: { type: 'string' },
+            bar: {},
+            foo: {},
           },
           type: 'object',
         })
@@ -440,7 +431,7 @@ describe('ObjectSchema', () => {
               },
             },
           },
-          properties: { foo: { type: 'string' } },
+          properties: { foo: {} },
           type: 'object',
         })
       })
@@ -515,12 +506,8 @@ describe('ObjectSchema', () => {
         foo: {
           type: 'object',
           properties: {
-            foo: {
-              type: 'string',
-            },
-            bar: {
-              type: 'string',
-            },
+            foo: {},
+            bar: {},
           },
         },
       })
@@ -542,12 +529,8 @@ describe('ObjectSchema', () => {
           $id: 'myDefId',
           type: 'object',
           properties: {
-            foo: {
-              type: 'string',
-            },
-            bar: {
-              type: 'string',
-            },
+            foo: {},
+            bar: {},
           },
         },
       })

--- a/src/example.js
+++ b/src/example.js
@@ -2,6 +2,11 @@
 const S = require('./FluentSchema')
 const Ajv = require('ajv')
 
+const ROLES = {
+  ADMIN: 'ADMIN',
+  USER: 'USER',
+}
+
 const schema = S.object()
   .id('http://foo/user')
   .title('My First Fluent JSON Schema')
@@ -18,23 +23,24 @@ const schema = S.object()
       .minLength(8)
       .required()
   )
-  .prop('role', S.enum(['ADMIN', 'USER']).default('USER'))
+  .prop(
+    'role',
+    S.string()
+      .enum(Object.values(ROLES))
+      .default(ROLES.USER)
+  )
   .definition(
     'address',
     S.object()
       .id('#address')
-      .prop('line1')
-      .required()
-      .prop('line2')
-      .prop('country')
-      .required()
-      .prop('city')
-      .required()
-      .prop('zipcode')
-      .required()
+      .prop('line1', S.string())
+      .prop('line2', S.string())
+      .prop('country', S.string())
+      .prop('city', S.string())
+      .prop('zipcode', S.string())
+      .required(['line1', 'country', 'city', 'zipcode'])
   )
-  .prop('address')
-  .ref('#address')
+  .prop('address', S.ref('#address'))
 
 console.log(JSON.stringify(schema.valueOf(), undefined, 2))
 


### PR DESCRIPTION
it's potentially a breaking change because previously this code:
```js
S.object().prop('foo')
```

was generating this schema:

```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "properties": {
    "foo": {
       "type": "string",
    }
  }
}

```

now it returns this one:

```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "properties": {
    "foo": {}
  }
}

```

which is correct because a prop without a `type` accepts `any`, not a `string`

I will release this as `v0.7.0`