### PR TITLE
Added symbol to identify fluent schema objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,18 @@ Output:
 
     {valid: true}
 
+### Detect Fluent Schema objects
+Every Fluent Schema objects contains a symbol that you can access with `Symbol.for('fluent-schema-object')`. In this way you can write your own utilities that understands the Fluent Schema API and improve the user experience of your tool.
+
+```js
+const S = require('fluent-schema')
+
+const schema = S.object()
+  .prop('foo', S.string())
+  .prop('bar', S.number())
+console.log(schema[Symbol.for('fluent-schema-object')]) // true
+```
+
 ## Documentation
 
 [API Doc](./docs/API.md).

--- a/src/ArraySchema.test.js
+++ b/src/ArraySchema.test.js
@@ -6,6 +6,10 @@ describe('ArraySchema', () => {
     expect(ArraySchema).toBeDefined()
   })
 
+  it('Expose symbol', () => {
+    expect(ArraySchema()[Symbol.for('fluent-schema-object')]).toBeDefined()
+  })
+
   describe('constructor', () => {
     it('without params', () => {
       expect(ArraySchema().valueOf()).toEqual({

--- a/src/BaseSchema.js
+++ b/src/BaseSchema.js
@@ -8,6 +8,7 @@ const {
   REQUIRED,
   setAttribute,
   setComposeType,
+  FLUENT_SCHEMA,
 } = require('./utils')
 
 const initialState = {
@@ -29,6 +30,7 @@ const BaseSchema = (
     factory: BaseSchema,
   }
 ) => ({
+  [FLUENT_SCHEMA]: true,
   /**
    * It defines a URI for the schema, and the base URI that other URI references within the schema are resolved against.
    *

--- a/src/BaseSchema.test.js
+++ b/src/BaseSchema.test.js
@@ -6,6 +6,10 @@ describe('BaseSchema', () => {
     expect(BaseSchema).toBeDefined()
   })
 
+  it('Expose symbol', () => {
+    expect(BaseSchema()[Symbol.for('fluent-schema-object')]).toBeDefined()
+  })
+
   describe('factory', () => {
     it('without params', () => {
       expect(BaseSchema().valueOf()).toEqual({})

--- a/src/BooleanSchema.test.js
+++ b/src/BooleanSchema.test.js
@@ -6,6 +6,10 @@ describe('BooleanSchema', () => {
     expect(BooleanSchema).toBeDefined()
   })
 
+  it('Expose symbol', () => {
+    expect(BooleanSchema()[Symbol.for('fluent-schema-object')]).toBeDefined()
+  })
+
   describe('constructor', () => {
     it('without params', () => {
       expect(BooleanSchema().valueOf()).toEqual({

--- a/src/IntegerSchema.test.js
+++ b/src/IntegerSchema.test.js
@@ -6,6 +6,10 @@ describe('IntegerSchema', () => {
     expect(IntegerSchema).toBeDefined()
   })
 
+  it('Expose symbol', () => {
+    expect(IntegerSchema()[Symbol.for('fluent-schema-object')]).toBeDefined()
+  })
+
   describe('constructor', () => {
     it('without params', () => {
       expect(IntegerSchema().valueOf()).toEqual({

--- a/src/MixedSchema.js
+++ b/src/MixedSchema.js
@@ -8,7 +8,7 @@ const { IntegerSchema } = require('./IntegerSchema')
 const { ObjectSchema } = require('./ObjectSchema')
 const { ArraySchema } = require('./ArraySchema')
 
-const { TYPES, setAttribute } = require('./utils')
+const { TYPES, setAttribute, FLUENT_SCHEMA } = require('./utils')
 
 const initialState = {
   type: [],
@@ -32,6 +32,7 @@ const MixedSchema = ({ schema = initialState, ...options } = {}) => {
     ...options,
   }
   return {
+    [FLUENT_SCHEMA]: true,
     ...(schema.type.includes(TYPES.STRING)
       ? StringSchema({ ...options, schema, factory: MixedSchema })
       : {}),

--- a/src/MixedSchema.test.js
+++ b/src/MixedSchema.test.js
@@ -6,9 +6,28 @@ describe('MixedSchema', () => {
     expect(MixedSchema).toBeDefined()
   })
 
+  it('Expose symbol / 1', () => {
+    expect(MixedSchema()[Symbol.for('fluent-schema-object')]).toBeDefined()
+  })
+
+  it('Expose symbol / 2', () => {
+    const types = [
+      S.TYPES.STRING,
+      S.TYPES.NUMBER,
+      S.TYPES.BOOLEAN,
+      S.TYPES.INTEGER,
+      S.TYPES.OBJECT,
+      S.TYPES.ARRAY,
+      S.TYPES.NULL,
+    ]
+    expect(MixedSchema(types)[Symbol.for('fluent-schema-object')]).toBeDefined()
+  })
+
   describe('factory', () => {
     it('without params', () => {
-      expect(MixedSchema().valueOf()).toEqual({})
+      expect(MixedSchema().valueOf()).toEqual({
+        [Symbol.for('fluent-schema-object')]: true,
+      })
     })
   })
 

--- a/src/NullSchema.js
+++ b/src/NullSchema.js
@@ -1,6 +1,6 @@
 'use strict'
 const { BaseSchema } = require('./BaseSchema')
-const { setAttribute } = require('./utils')
+const { setAttribute, FLUENT_SCHEMA } = require('./utils')
 
 const initialState = {
   type: 'null',
@@ -23,6 +23,7 @@ const NullSchema = ({ schema = initialState, ...options } = {}) => {
   const { valueOf } = BaseSchema({ ...options, schema })
   return {
     valueOf,
+    [FLUENT_SCHEMA]: true,
 
     /**
      * Set a property to type null

--- a/src/NullSchema.test.js
+++ b/src/NullSchema.test.js
@@ -6,6 +6,10 @@ describe('NullSchema', () => {
     expect(NullSchema).toBeDefined()
   })
 
+  it('Expose symbol', () => {
+    expect(NullSchema()[Symbol.for('fluent-schema-object')]).toBeDefined()
+  })
+
   describe('constructor', () => {
     it('without params', () => {
       expect(NullSchema().valueOf()).toEqual({

--- a/src/NumberSchema.test.js
+++ b/src/NumberSchema.test.js
@@ -6,6 +6,10 @@ describe('NumberSchema', () => {
     expect(NumberSchema).toBeDefined()
   })
 
+  it('Expose symbol', () => {
+    expect(NumberSchema()[Symbol.for('fluent-schema-object')]).toBeDefined()
+  })
+
   describe('constructor', () => {
     it('without params', () => {
       expect(NumberSchema().valueOf()).toEqual({

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -6,6 +6,10 @@ describe('ObjectSchema', () => {
     expect(ObjectSchema).toBeDefined()
   })
 
+  it('Expose symbol', () => {
+    expect(ObjectSchema()[Symbol.for('fluent-schema-object')]).toBeDefined()
+  })
+
   describe('constructor', () => {
     it('without params', () => {
       expect(ObjectSchema().valueOf()).toEqual({

--- a/src/StringSchema.test.js
+++ b/src/StringSchema.test.js
@@ -6,6 +6,10 @@ describe('StringSchema', () => {
     expect(StringSchema).toBeDefined()
   })
 
+  it('Expose symbol', () => {
+    expect(StringSchema()[Symbol.for('fluent-schema-object')]).toBeDefined()
+  })
+
   describe('constructor', () => {
     it('without params', () => {
       expect(StringSchema().valueOf()).toEqual({

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,6 +35,7 @@ const flat = array =>
   }, {})
 
 const REQUIRED = Symbol('required')
+const FLUENT_SCHEMA = Symbol.for('fluent-schema-object')
 
 const RELATIVE_JSON_POINTER = 'relative-json-pointer'
 const JSON_POINTER = 'json-pointer'
@@ -183,4 +184,5 @@ module.exports = {
   setComposeType,
   FORMATS,
   TYPES,
+  FLUENT_SCHEMA,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,6 @@
 'use strict'
-const isFluentSchema = obj =>
-  obj &&
-  (typeof obj.anyOf === 'function' || // BaseSchema
-  typeof obj.definition === 'function' || // ObjectSchema
-  typeof obj.items === 'function' || // ArraySchema
-  typeof obj.min === 'function' || // NumberSchema & IntegerSchema
-  typeof obj.format === 'function' || // StringSchema
-    typeof obj.null === 'function') // NullSchema
+
+const isFluentSchema = obj => obj && obj[FLUENT_SCHEMA]
 
 const hasCombiningKeywords = attributes =>
   attributes.allOf || attributes.anyOf || attributes.oneOf || attributes.not


### PR DESCRIPTION
As titled.
Thanks to this symbol, other libraries that accept validation objects, can directly accept fluent schema objects and call `.valueOf` internally.
This vastly improves the user experience and hides one of the most common mistakes that devs make with this library.

```js
const S = require('fluent-schema')

const schema = S.object()
  .prop('foo', S.string())
  .prop('bar', S.number())

console.log(schema[Symbol.for('fluent-schema-object')]) // true
```

Once this pr is merged and released, I'll open a pr to Fastify to support this new feature.