### PR TITLE
Add boolean to detect object type

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,16 @@ const schema = S.object()
 console.log(schema[Symbol.for('fluent-schema-object')]) // true
 ```
 
+Alternatively, you can use the `isFluentSchema` boolean:
+
+```js
+const S = require('fluent-schema')
+const schema = S.object()
+  .prop('foo', S.string())
+  .prop('bar', S.number())
+console.log(schema.isFluentSchema) // true
+```
+
 ## Documentation
 
 [API Doc](./docs/API.md).

--- a/README.md
+++ b/README.md
@@ -268,18 +268,7 @@ Output:
     {valid: true}
 
 ### Detect Fluent Schema objects
-Every Fluent Schema objects contains a symbol that you can access with `Symbol.for('fluent-schema-object')`. In this way you can write your own utilities that understands the Fluent Schema API and improve the user experience of your tool.
-
-```js
-const S = require('fluent-schema')
-
-const schema = S.object()
-  .prop('foo', S.string())
-  .prop('bar', S.number())
-console.log(schema[Symbol.for('fluent-schema-object')]) // true
-```
-
-Alternatively, you can use the `isFluentSchema` boolean:
+Every Fluent Schema objects contains a boolean `isFluentSchema`. In this way you can write your own utilities that understands the Fluent Schema API and improve the user experience of your tool.
 
 ```js
 const S = require('fluent-schema')

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "jest": "^24.3.1",
     "jsdoc-to-markdown": "^4.0.1",
     "lint-staged": "^8.0.4",
+    "lodash.merge": "^4.6.2",
     "prettier": "^1.14.3",
     "typescript": "^3.2.2"
-  },
-  "dependencies": {}
+  }
 }

--- a/src/BaseSchema.js
+++ b/src/BaseSchema.js
@@ -31,6 +31,8 @@ const BaseSchema = (
   }
 ) => ({
   [FLUENT_SCHEMA]: true,
+  isFluentSchema: true,
+
   /**
    * It defines a URI for the schema, and the base URI that other URI references within the schema are resolved against.
    *

--- a/src/BaseSchema.test.js
+++ b/src/BaseSchema.test.js
@@ -10,6 +10,10 @@ describe('BaseSchema', () => {
     expect(BaseSchema()[Symbol.for('fluent-schema-object')]).toBeDefined()
   })
 
+  it('Expose plain boolean', () => {
+    expect(BaseSchema().isFluentSchema).toBeDefined()
+  })
+
   describe('factory', () => {
     it('without params', () => {
       expect(BaseSchema().valueOf()).toEqual({})

--- a/src/FluentSchema.integration.test.js
+++ b/src/FluentSchema.integration.test.js
@@ -190,6 +190,38 @@ describe('S', () => {
     })
   })
 
+  // https://github.com/fastify/fluent-schema/pull/40
+  describe('cloning objects retains boolean', () => {
+    const ajv = new Ajv()
+    const config = {
+      schema: S.object().prop('foo', S.string().enum(['foo']))
+    }
+    const _config = require('lodash.merge')({}, config)
+    expect(config.schema[Symbol.for('fluent-schema-object')]).toBeDefined()
+    expect(_config.schema.isFluentSchema).toBeTruthy()
+    expect(_config.schema[Symbol.for('fluent-schema-object')]).toBeUndefined()
+    const schema = _config.schema.valueOf()
+    const validate = ajv.compile(schema)
+    it('matches', () => {
+      expect(schema).toEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string',
+            enum: ['foo']
+          }
+        }
+      })
+    })
+
+    it('valid', () => {
+      const valid = validate({foo: 'foo'})
+      expect(validate.errors).toEqual(null)
+      expect(valid).toBeTruthy()
+    })
+  })
+
   describe('compose keywords', () => {
     const ajv = new Ajv()
     const schema = S.object()

--- a/src/NullSchema.js
+++ b/src/NullSchema.js
@@ -24,6 +24,7 @@ const NullSchema = ({ schema = initialState, ...options } = {}) => {
   return {
     valueOf,
     [FLUENT_SCHEMA]: true,
+    isFluentSchema: true,
 
     /**
      * Set a property to type null

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const isFluentSchema = obj => obj && obj[FLUENT_SCHEMA]
+const isFluentSchema = obj => obj && obj.isFluentSchema
 
 const hasCombiningKeywords = attributes =>
   attributes.allOf || attributes.anyOf || attributes.oneOf || attributes.not


### PR DESCRIPTION
The issue I was having in #39 was due to object composition and cloning. I have a wrapper around Fastify that reads a list of routes from `config/routes.js` and then the corresponding handlers from `lib/handlers/`. For example:

`config/routes.js`:
```js
module.exports = [{
  path: '/foo',
  method: 'GET',
  handler: 'foo'
}]
```

`lib/handlers/foo.js`:
```js
module.exports = {
  schema: {
    query: { fluent.object().prop('foo', fluent.string()) }
  },
  handler(req, res) {
    res.send(req.query)
  }
}
```

So these two files are read in and the objects are merged to build up the full route definition before being passed to `fastify.route`. If any of the schemas are `fluent-schema` instances then the `Symbol.for('fluent-schema-object')` will be lost during this process because symbols do not get copied in any current object merging method (by design). But if we don't retain the ability to determine if the schemas are instances of `fluent-schema` then we can't work with these schemas during the schema compilation process. Thus, this PR adds an `isFluentSchema` boolean to use instead of the symbol.