### PR TITLE
Compose schemas #46

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,30 @@ Output:
 
     {valid: true}
 
+## Advance usage
+
+You can combine different schemas
+
+```js
+const S = require('fluent-schema')
+const userBaseSchema = S.object()
+  .additionalProperties(false)
+  .prop('username', S.string())
+  .prop('password', S.string())
+
+const userSchema = S.object(userBaseSchema).prop(
+  'id',
+  S.string().format('uuid')
+)
+
+console.log(userSchema)
+```
+
+This useful for a CRUD api where POST /users uses the `userBaseSchema` rather than GET /users uses the `userSchema`
+which contains the id generated server sidegs
+
 ### Detect Fluent Schema objects
+
 Every Fluent Schema objects contains a boolean `isFluentSchema`. In this way you can write your own utilities that understands the Fluent Schema API and improve the user experience of your tool.
 
 ```js
@@ -284,6 +307,8 @@ const schema = S.object()
   .prop('bar', S.number())
 console.log(schema.isFluentSchema) // true
 ```
+
+## Usage
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -274,9 +274,13 @@ Output:
 
     {valid: true}
 
-## Advance usage
+## Extend schema
 
-You can combine different schemas
+Normally inheritance with JSON Schema is achieved with `allOf`. However when `.additionalProperties(false)` is used the validator won't
+understand which properties come from the base schema. `S.extend` creates a schema merging the base into the new one so
+that the validator knows all the properties because it's evaluating only a single schema.
+For example in a CRUD API `POST /users` could use the `userBaseSchema` rather than `GET /users` or `PATCH /users` use the `userSchema`
+which contains the `id`, `createdAt` and `updatedAt` generated server side.
 
 ```js
 const S = require('fluent-schema')
@@ -285,16 +289,13 @@ const userBaseSchema = S.object()
   .prop('username', S.string())
   .prop('password', S.string())
 
-const userSchema = S.object(userBaseSchema).prop(
-  'id',
-  S.string().format('uuid')
-)
+const userSchema = S.extend(userBaseSchema)
+  .prop('id', S.string().format('uuid'))
+  .prop('createdAt', S.string().format('time'))
+  .prop('updatedAt', S.string().format('time'))
 
 console.log(userSchema)
 ```
-
-This useful for a CRUD api where POST /users uses the `userBaseSchema` rather than GET /users uses the `userSchema`
-which contains the id generated server sidegs
 
 ### Detect Fluent Schema objects
 

--- a/README.md
+++ b/README.md
@@ -309,8 +309,6 @@ const schema = S.object()
 console.log(schema.isFluentSchema) // true
 ```
 
-## Usage
-
 ## Documentation
 
 [API Doc](./docs/API.md).

--- a/src/BaseSchema.js
+++ b/src/BaseSchema.js
@@ -363,6 +363,10 @@ const BaseSchema = (
     })
   },
 
+  _getState: () => {
+    return schema
+  },
+
   /**
    * It returns all the schema values
    *

--- a/src/BaseSchema.js
+++ b/src/BaseSchema.js
@@ -253,12 +253,7 @@ const BaseSchema = (
    * @private set a property to a type. Use string number etc.
    * @returns {BaseSchema}
    */
-  as: type => {
-    return setAttribute({ schema, ...options }, ['type', type])
-    // return type !== schema.type
-    //   ?
-    //   : options.factory({ schema, ...options })
-  },
+  as: type => setAttribute({ schema, ...options }, ['type', type]),
 
   /**
    * This validation outcome of this keyword's subschema has no direct effect on the overall validation result.

--- a/src/BaseSchema.js
+++ b/src/BaseSchema.js
@@ -254,9 +254,10 @@ const BaseSchema = (
    * @returns {BaseSchema}
    */
   as: type => {
-    return type !== schema.type
-      ? setAttribute({ schema, ...options }, ['type', type])
-      : options.factory({ schema, ...options })
+    return setAttribute({ schema, ...options }, ['type', type])
+    // return type !== schema.type
+    //   ?
+    //   : options.factory({ schema, ...options })
   },
 
   /**

--- a/src/BaseSchema.js
+++ b/src/BaseSchema.js
@@ -254,7 +254,9 @@ const BaseSchema = (
    * @returns {BaseSchema}
    */
   as: type => {
-    return setAttribute({ schema, ...options }, ['type', type])
+    return type !== schema.type
+      ? setAttribute({ schema, ...options }, ['type', type])
+      : options.factory({ schema, ...options })
   },
 
   /**
@@ -363,6 +365,10 @@ const BaseSchema = (
     })
   },
 
+  /**
+   * @private It returns the internal schema data structure
+   * @returns {object}
+   */
   _getState: () => {
     return schema
   },

--- a/src/FluentSchema.d.ts
+++ b/src/FluentSchema.d.ts
@@ -145,6 +145,7 @@ export interface S extends BaseSchema<S> {
   array: () => ArraySchema
   object: () => ObjectSchema
   null: () => NullSchema
+  extend: (schema: ObjectSchema) => ObjectSchema
   //FIXME LS we should return only a MixedSchema
   mixed: <T>(types: TYPE[]) => MixedSchema<T> & any
 }

--- a/src/FluentSchema.integration.test.js
+++ b/src/FluentSchema.integration.test.js
@@ -194,7 +194,7 @@ describe('S', () => {
   describe('cloning objects retains boolean', () => {
     const ajv = new Ajv()
     const config = {
-      schema: S.object().prop('foo', S.string().enum(['foo']))
+      schema: S.object().prop('foo', S.string().enum(['foo'])),
     }
     const _config = require('lodash.merge')({}, config)
     expect(config.schema[Symbol.for('fluent-schema-object')]).toBeDefined()
@@ -209,14 +209,14 @@ describe('S', () => {
         properties: {
           foo: {
             type: 'string',
-            enum: ['foo']
-          }
-        }
+            enum: ['foo'],
+          },
+        },
       })
     })
 
     it('valid', () => {
-      const valid = validate({foo: 'foo'})
+      const valid = validate({ foo: 'foo' })
       expect(validate.errors).toEqual(null)
       expect(valid).toBeTruthy()
     })
@@ -480,6 +480,36 @@ describe('S', () => {
           )
           .valueOf()
       ).toEqual(step.schema)
+    })
+  })
+
+  describe('null', () => {
+    it.only('throws an execption if the property is null', () => {
+      const room = S.object()
+        .prop('_id', S.string())
+        .prop('owner', S.string())
+        .prop('name', S.string())
+        .prop('moderators', S.array().items(S.string()))
+        .prop('members', S.array().items(S.string()))
+
+      const invite = S.object()
+        .prop('inviter', S.string())
+        .prop('room', room) // THROWS an error if property room has null value
+        .prop('email', S.string())
+        .prop('type', S.string())
+        .prop('createdAt', S.string())
+        .prop('updatedAt', S.string())
+        .required(['room'])
+
+      const ajv = new Ajv().valueOf()
+      const validate = ajv.compile(invite.valueOf())
+      const isValid = validate({
+        room: null,
+      })
+
+      console.log('\n', JSON.stringify(invite.valueOf(), undefined, 2))
+      console.log(validate.errors)
+      expect(isValid).toBeFalsy()
     })
   })
 })

--- a/src/FluentSchema.integration.test.js
+++ b/src/FluentSchema.integration.test.js
@@ -482,34 +482,4 @@ describe('S', () => {
       ).toEqual(step.schema)
     })
   })
-
-  describe('null', () => {
-    it.only('throws an execption if the property is null', () => {
-      const room = S.object()
-        .prop('_id', S.string())
-        .prop('owner', S.string())
-        .prop('name', S.string())
-        .prop('moderators', S.array().items(S.string()))
-        .prop('members', S.array().items(S.string()))
-
-      const invite = S.object()
-        .prop('inviter', S.string())
-        .prop('room', room) // THROWS an error if property room has null value
-        .prop('email', S.string())
-        .prop('type', S.string())
-        .prop('createdAt', S.string())
-        .prop('updatedAt', S.string())
-        .required(['room'])
-
-      const ajv = new Ajv().valueOf()
-      const validate = ajv.compile(invite.valueOf())
-      const isValid = validate({
-        room: null,
-      })
-
-      console.log('\n', JSON.stringify(invite.valueOf(), undefined, 2))
-      console.log(validate.errors)
-      expect(isValid).toBeFalsy()
-    })
-  })
 })

--- a/src/FluentSchema.js
+++ b/src/FluentSchema.js
@@ -111,10 +111,10 @@ const S = (
    * @returns {ObjectSchema}
    */
 
-  object: () =>
+  object: baseSchema =>
     ObjectSchema({
       ...options,
-      schema,
+      schema: baseSchema || schema,
       factory: ObjectSchema,
     }).as('object'),
 
@@ -169,7 +169,18 @@ module.exports = {
   withOptions: S,
   string: () => S().string(),
   mixed: types => S().mixed(types),
-  object: () => S().object(),
+  // object: () => S().object(),
+  object: schema => {
+    if (schema && !schema.isFluentSchema)
+      throw new Error('schema has to be FluentSchema type')
+    if (schema) {
+      const state = schema._getState()
+      console.log({ schema: JSON.stringify(schema.valueOf(), undefined, 2) })
+      console.log({ state: JSON.stringify(state, undefined, 2) })
+      return S().object(state)
+    }
+    return S().object()
+  },
   array: () => S().array(),
   boolean: () => S().boolean(),
   integer: () => S().integer(),

--- a/src/FluentSchema.js
+++ b/src/FluentSchema.js
@@ -171,13 +171,14 @@ module.exports = {
   mixed: types => S().mixed(types),
   object: () => S().object(),
   extend: schema => {
-    if (!schema || (schema && !schema.isFluentSchema))
-      throw new Error('schema has to be FluentSchema type')
-    if (schema) {
-      const state = schema._getState()
-      return S().object(state)
+    if (!schema) {
+      throw new Error("Schema can't be null or undefined")
     }
-    return S().object()
+    if (!schema.isFluentSchema) {
+      throw new Error("Schema isn't FluentSchema type")
+    }
+    const state = schema._getState()
+    return S().object(state)
   },
   array: () => S().array(),
   boolean: () => S().boolean(),

--- a/src/FluentSchema.js
+++ b/src/FluentSchema.js
@@ -169,9 +169,9 @@ module.exports = {
   withOptions: S,
   string: () => S().string(),
   mixed: types => S().mixed(types),
-  // object: () => S().object(),
-  object: schema => {
-    if (schema && !schema.isFluentSchema)
+  object: () => S().object(),
+  extend: schema => {
+    if (!schema || (schema && !schema.isFluentSchema))
       throw new Error('schema has to be FluentSchema type')
     if (schema) {
       const state = schema._getState()
@@ -179,7 +179,6 @@ module.exports = {
     }
     return S().object()
   },
-
   array: () => S().array(),
   boolean: () => S().boolean(),
   integer: () => S().integer(),

--- a/src/FluentSchema.js
+++ b/src/FluentSchema.js
@@ -175,12 +175,11 @@ module.exports = {
       throw new Error('schema has to be FluentSchema type')
     if (schema) {
       const state = schema._getState()
-      console.log({ schema: JSON.stringify(schema.valueOf(), undefined, 2) })
-      console.log({ state: JSON.stringify(state, undefined, 2) })
       return S().object(state)
     }
     return S().object()
   },
+
   array: () => S().array(),
   boolean: () => S().boolean(),
   integer: () => S().integer(),

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -550,4 +550,77 @@ describe('ObjectSchema', () => {
       })
     })
   })
+
+  describe('compose', () => {
+    it('merges two simple schemas', () => {
+      const base = S.object()
+        .additionalProperties(false)
+        .prop('foo', S.string())
+
+      const extended = S.object(base).prop('bar', S.number())
+
+      expect(extended.valueOf()).toEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        additionalProperties: false,
+        properties: {
+          foo: {
+            type: 'string',
+          },
+          bar: {
+            type: 'number',
+          },
+        },
+        type: 'object',
+      })
+    })
+    it('merges two nested schemas', () => {
+      const base = S.object()
+        .additionalProperties(false)
+        .prop(
+          'foo',
+          S.object().prop(
+            'id',
+            S.string()
+              .format('uuid')
+              .required()
+          )
+        )
+        .prop('str', S.string().required())
+        .prop('bol', S.boolean().required())
+        .prop('num', S.integer().required())
+
+      const extended = S.object(base).prop('bar', S.number())
+
+      expect(extended.valueOf()).toEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        additionalProperties: false,
+        properties: {
+          foo: {
+            type: 'object',
+            properties: {
+              id: {
+                type: 'string',
+                format: 'uuid',
+              },
+            },
+            required: ['id'],
+          },
+          bar: {
+            type: 'number',
+          },
+          str: {
+            type: 'string',
+          },
+          bol: {
+            type: 'boolean',
+          },
+          num: {
+            type: 'integer',
+          },
+        },
+        required: ['str', 'bol', 'num'],
+        type: 'object',
+      })
+    })
+  })
 })

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -555,7 +555,7 @@ describe('ObjectSchema', () => {
     it('merges two simple schemas', () => {
       const base = S.object()
         .additionalProperties(false)
-        .prop('foo', S.string())
+        .prop('foo', S.string().minLength(5))
 
       const extended = S.object(base).prop('bar', S.number())
 
@@ -565,6 +565,7 @@ describe('ObjectSchema', () => {
         properties: {
           foo: {
             type: 'string',
+            minLength: 5,
           },
           bar: {
             type: 'number',

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -551,13 +551,13 @@ describe('ObjectSchema', () => {
     })
   })
 
-  describe('compose', () => {
-    it('merges two simple schemas', () => {
+  describe('extend', () => {
+    it('extends a simple schema', () => {
       const base = S.object()
         .additionalProperties(false)
         .prop('foo', S.string().minLength(5))
 
-      const extended = S.object(base).prop('bar', S.number())
+      const extended = S.extend(base).prop('bar', S.number())
 
       expect(extended.valueOf()).toEqual({
         $schema: 'http://json-schema.org/draft-07/schema#',
@@ -574,7 +574,7 @@ describe('ObjectSchema', () => {
         type: 'object',
       })
     })
-    it('merges two nested schemas', () => {
+    it('extends a nested schema', () => {
       const base = S.object()
         .additionalProperties(false)
         .prop(
@@ -590,7 +590,7 @@ describe('ObjectSchema', () => {
         .prop('bol', S.boolean().required())
         .prop('num', S.integer().required())
 
-      const extended = S.object(base).prop('bar', S.number())
+      const extended = S.extend(base).prop('bar', S.number())
 
       expect(extended.valueOf()).toEqual({
         $schema: 'http://json-schema.org/draft-07/schema#',

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -623,5 +623,15 @@ describe('ObjectSchema', () => {
         type: 'object',
       })
     })
+    it('throws an error if a schema is not provided', () => {
+      expect(() => {
+        S.extend()
+      }).toThrow("Schema can't be null or undefined")
+    })
+    it('throws an error if a schema is not provided', () => {
+      expect(() => {
+        S.extend('boom!')
+      }).toThrow("Schema isn't FluentSchema type")
+    })
   })
 })

--- a/src/example.js
+++ b/src/example.js
@@ -107,3 +107,11 @@ console.log(validate.errors)
     params: { missingProperty: 'zipcoce' },
     message: 'should have required property \'zipcode\'' } ]
 */
+
+const base = S.object()
+  .additionalProperties(false)
+  .prop('foo', S.string())
+
+const extended = S.object(base).prop('bar', S.number())
+
+console.log(extended.valueOf())

--- a/src/example.js
+++ b/src/example.js
@@ -108,10 +108,15 @@ console.log(validate.errors)
     message: 'should have required property \'zipcode\'' } ]
 */
 
-const base = S.object()
+const userBaseSchema = S.object()
   .additionalProperties(false)
-  .prop('foo', S.string())
+  .prop('username', S.string())
+  .prop('password', S.string())
 
-const extended = S.object(base).prop('bar', S.number())
+const userSchema = S.extend(userBaseSchema)
+  .prop('id', S.string().format('uuid'))
+  .prop('createdAt', S.string().format('time'))
+  .prop('updatedAt', S.string().format('time'))
+  .valueOf()
 
-console.log(extended.valueOf())
+console.log(userSchema.valueOf())

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,8 +51,20 @@ const schema = S.object()
   .ifThen(S.object().prop('age', S.string()), S.required(['age']))
   .readOnly()
   .writeOnly(true)
-
   .valueOf()
 
 console.log(JSON.stringify(schema))
 console.log(S.object().isFluentSchema)
+
+const userBaseSchema = S.object()
+  .additionalProperties(false)
+  .prop('username', S.string())
+  .prop('password', S.string())
+
+const userSchema = S.extend(userBaseSchema)
+  .prop('id', S.string().format('uuid'))
+  .prop('createdAt', S.string().format('time'))
+  .prop('updatedAt', S.string().format('time'))
+  .valueOf()
+
+console.log('\n user:', JSON.stringify(userSchema))

--- a/src/utils.js
+++ b/src/utils.js
@@ -140,7 +140,8 @@ const appendRequired = ({
 const setAttribute = ({ schema, ...options }, attribute) => {
   const [key, value] = attribute
   const currentProp = last(schema.properties)
-  if (currentProp) {
+  // TODO LS I don't get why it could occur an override as for 'it merges two simple schemas'
+  if (currentProp && !currentProp[key]) {
     const { name, ...props } = currentProp
     return options.factory({ schema, ...options }).prop(name, {
       ...props,

--- a/src/utils.js
+++ b/src/utils.js
@@ -143,8 +143,8 @@ const setAttribute = ({ schema, ...options }, attribute) => {
   if (currentProp) {
     const { name, ...props } = currentProp
     return options.factory({ schema, ...options }).prop(name, {
-      ...props,
       [key]: value,
+      ...props,
     })
   }
   return options.factory({ schema: { ...schema, [key]: value }, ...options })

--- a/src/utils.js
+++ b/src/utils.js
@@ -140,8 +140,7 @@ const appendRequired = ({
 const setAttribute = ({ schema, ...options }, attribute) => {
   const [key, value] = attribute
   const currentProp = last(schema.properties)
-  // TODO LS I don't get why it could occur an override as for 'it merges two simple schemas'
-  if (currentProp && !currentProp[key]) {
+  if (currentProp) {
     const { name, ...props } = currentProp
     return options.factory({ schema, ...options }).prop(name, {
       ...props,


### PR DESCRIPTION
Normally inheritance with JSON Schema is achieved with `allOf`. However when `.additionalProperties(false)` is used the validator won't
understand which properties come from the base schema. `S.extend` creates a schema merging the base into the new one so that the validator knows all the properties because it's evaluating only a single schema.
For example in a CRUD API `POST /users` could use the `userBaseSchema` rather than `GET /users` or `PATCH /users` use the `userSchema` whose contains the `id`, `createdAt` and `updatedAt` generated server side

related to #46 