### PR TITLE
Extend schema fixes #65

### DIFF
--- a/src/ObjectSchema.js
+++ b/src/ObjectSchema.js
@@ -9,6 +9,7 @@ const {
   patchIdsWithParentId,
   appendRequired,
   FluentSchemaError,
+  combineMerge,
 } = require('./utils')
 
 const initialState = {
@@ -264,10 +265,10 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
       if (!base.isFluentSchema) {
         throw new FluentSchemaError("Schema isn't FluentSchema type")
       }
-      const state = base._getState()
-      const extended = merge(state, schema)
+      const src = base._getState()
+      const extended = merge(src, schema, { arrayMerge: combineMerge })
 
-      return ObjectSchema({ schema: extended, ...options })
+      return BaseSchema({ schema: extended, ...options })
     },
 
     /**

--- a/src/ObjectSchema.js
+++ b/src/ObjectSchema.js
@@ -267,8 +267,8 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
       }
       const src = base._getState()
       const extended = merge(src, schema, { arrayMerge: combineMerge })
-
-      return BaseSchema({ schema: extended, ...options })
+      const { valueOf, ...rest } = BaseSchema({ schema: extended, ...options })
+      return { valueOf }
     },
 
     /**

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -730,6 +730,7 @@ describe('ObjectSchema', () => {
       const base = S.object().prop('reason', S.string().title('title'))
 
       const extended = S.object()
+        .prop('other')
         .prop('reason', S.string().minLength(1))
         .extend(base)
 
@@ -737,6 +738,7 @@ describe('ObjectSchema', () => {
         $schema: 'http://json-schema.org/draft-07/schema#',
         type: 'object',
         properties: {
+          other: {},
           reason: { title: 'title', type: 'string', minLength: 1 },
         },
       })

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -607,7 +607,6 @@ describe('ObjectSchema', () => {
         .title('extended')
         .prop('bar', S.number())
         .extend(base)
-
       expect(extended.valueOf()).toEqual({
         $schema: 'http://json-schema.org/draft-07/schema#',
         $id: 'extended',
@@ -707,7 +706,7 @@ describe('ObjectSchema', () => {
       expect(extended.valueOf()).toEqual({
         $schema: 'http://json-schema.org/draft-07/schema#',
         definitions: {
-          def1: { type: 'object', properties: { someExtended: {} } },
+          def1: { type: 'object', properties: { some: {}, someExtended: {} } },
           def2: { type: 'object', properties: { somethingElse: {} } },
         },
         type: 'object',
@@ -727,6 +726,21 @@ describe('ObjectSchema', () => {
         required: ['str', 'bol', 'num'],
       })
     })
+    it('extends a schema overriding the props', () => {
+      const base = S.object().prop('reason', S.string().title('title'))
+
+      const extended = S.object()
+        .prop('reason', S.string().minLength(1))
+        .extend(base)
+
+      expect(extended.valueOf()).toEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: {
+          reason: { title: 'title', type: 'string', minLength: 1 },
+        },
+      })
+    })
 
     it('throws an error if a schema is not provided', () => {
       expect(() => {
@@ -735,10 +749,24 @@ describe('ObjectSchema', () => {
         new S.FluentSchemaError("Schema can't be null or undefined")
       )
     })
-    it('throws an error if a schema is not provided', () => {
+
+    it('throws an error if a schema is invalid', () => {
       expect(() => {
         S.object().extend('boom!')
       }).toThrowError(new S.FluentSchemaError("Schema isn't FluentSchema type"))
+    })
+
+    it('throws an error if you append a new prop after extend', () => {
+      expect(() => {
+        const base = S.object()
+        S.object()
+          .extend(base)
+          .prop('foo')
+      }).toThrowError(
+        new S.FluentSchemaError(
+          'S.object(...).extend(...).prop is not a function'
+        )
+      )
     })
   })
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 'use strict'
-
+const merge = require('deepmerge')
 const isFluentSchema = obj => obj && obj.isFluentSchema
 
 const hasCombiningKeywords = attributes =>
@@ -35,6 +35,23 @@ const flat = array =>
       [name]: rest,
     }
   }, {})
+
+// https://github.com/TehShrike/deepmerge#arraymerge-example-combine-arrays
+// This was the default array merging algorithm pre-version-2.0.0.
+const combineMerge = (target, source, options) => {
+  const destination = target.slice()
+
+  source.forEach((item, index) => {
+    if (typeof destination[index] === 'undefined') {
+      destination[index] = options.cloneUnlessOtherwiseSpecified(item, options)
+    } else if (item.name === target[index].name) {
+      destination[index] = merge(target[index], item, options)
+    } else if (target.indexOf(item) === -1) {
+      destination.push(item)
+    }
+  })
+  return destination
+}
 
 const toArray = obj =>
   obj && Object.entries(obj).map(([key, value]) => ({ name: key, ...value }))
@@ -202,6 +219,7 @@ module.exports = {
   setRaw,
   setAttribute,
   setComposeType,
+  combineMerge,
   FORMATS,
   TYPES,
   FLUENT_SCHEMA,

--- a/src/utils.js
+++ b/src/utils.js
@@ -36,16 +36,16 @@ const flat = array =>
     }
   }, {})
 
-// https://github.com/TehShrike/deepmerge#arraymerge-example-combine-arrays
-// This was the default array merging algorithm pre-version-2.0.0.
 const combineMerge = (target, source, options) => {
   const destination = target.slice()
 
   source.forEach((item, index) => {
+    const prop = target.find(prop => prop.name === item.name)
     if (typeof destination[index] === 'undefined') {
       destination[index] = options.cloneUnlessOtherwiseSpecified(item, options)
-    } else if (item.name === target[index].name) {
-      destination[index] = merge(target[index], item, options)
+    } else if (prop) {
+      const propIndex = target.findIndex(prop => prop.name === item.name)
+      destination[propIndex] = merge(prop, item, options)
     } else if (target.indexOf(item) === -1) {
       destination.push(item)
     }


### PR DESCRIPTION
Better merge strategy. Before, the merge was replacing the array element rather than merging the items. 
I decided to block all the method after `.extend` to avoid incorrect usage. 

Wrong but no error raised by FluentSchema

```
const SCHEMA_BASE = S.object()
  .prop(
    'reason',
    S.string()
      .title('Reason 1')
  )

const base = S.object()
  .extend(SCHEMA_BASE)
  .prop(
    'reason',
    S.string()
      .minLength(1)
  )
  
```

Correct usage should be:

```
const extended = S.object()
  .prop(
    'reason',
    S.string()
      .minLength(1)
  )
  .extend(SCHEMA_BASE)
```

First, the schema is defined with all the props then it extends the base schema. 

With the sealed schema after the `.extend` the only thing that can be done is calling `valueOf` 

I'm unsure if I should mark this as 1.0.2 because it's a bug fix or considering the sealing as breaking change. Feedback welcome. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)