### PR TITLE
fix: allow empty array as default value for a prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ typings/
 
 # next.js build output
 .next
+
+.vscode

--- a/src/ArraySchema.test.js
+++ b/src/ArraySchema.test.js
@@ -180,5 +180,17 @@ describe('ArraySchema', () => {
         })
       })
     })
+
+    describe('default array in an object', () => {
+      it('valid', () => {
+        const value = []
+        expect(
+          S.object()
+            .prop('p1', ArraySchema().default(value))
+            .valueOf()
+            .properties.p1.default
+        ).toBe(value)
+      })
+    })
   })
 })

--- a/src/ObjectSchema.js
+++ b/src/ObjectSchema.js
@@ -238,7 +238,7 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
           return key === '$schema' ||
             key === 'def' ||
             value === undefined ||
-            (Array.isArray(value) && value.length === 0)
+            (Array.isArray(value) && value.length === 0 && key !== 'default')
             ? memo
             : { ...memo, [key]: value }
         },


### PR DESCRIPTION
Allow empty array as default value for a prop.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
