### PR TITLE
Highlight that this package is framework agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fluent-schema
 
-A fluent API to generate JSON schemas (draft-07) for Node.js and browser.
+A fluent API to generate JSON schemas (draft-07) for Node.js and browser. Framework agnostic.
 
 [![view on npm](https://img.shields.io/npm/v/fluent-schema.svg)](https://www.npmjs.org/package/fluent-schema)
 [![Build Status](https://travis-ci.com/fastify/fluent-schema.svg?branch=master)](https://travis-ci.com/fastify/fluent-schema?branch=master)


### PR DESCRIPTION
Even though this package's name is not prefixed with `fastify-*`, I still initially assumed that it was only intended for use with Fastify. I think it might encourage more widespread usage if the README highlights that this package is framework agnostic.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
