### PR TITLE
Adds 'only' to ObjectSchema to return a subset of properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,23 @@ const userSchema = S.object()
 console.log(userSchema)
 ```
 
+## Selecting only certain properties of your schema
+
+In addition to extending schemas, it is also possible to reduce them into smaller schemas. This comes in handy
+when you have a large Fluent Schema, and would like to re-use some of its properties.
+
+```js
+const S = require('fluid-schema')
+const userSchema = S.object()
+  .prop('username', S.string())
+  .prop('password', S.string())
+  .prop('id', S.string().format('uuid'))
+  .prop('createdAt', S.string().format('time'))
+  .prop('updatedAt', S.string().format('time'))
+
+const loginSchema = userSchema.only(['username', 'password'])
+```
+
 ### Detect Fluent Schema objects
 
 Every Fluent Schema objects contains a boolean `isFluentSchema`. In this way you can write your own utilities that understands the Fluent Schema API and improve the user experience of your tool.

--- a/src/FluentSchema.d.ts
+++ b/src/FluentSchema.d.ts
@@ -122,6 +122,7 @@ export interface ObjectSchema extends BaseSchema<ObjectSchema> {
   dependencies: (options: DependenciesOptions) => ObjectSchema
   propertyNames: (value: JSONSchema) => ObjectSchema
   extend: (schema: ObjectSchema) => ExtendedSchema
+  only: (properties: string[]) => ObjectSchema
 }
 
 export type ExtendedSchema = Pick<ObjectSchema, 'isFluentSchema' | 'extend'>

--- a/src/ObjectSchema.js
+++ b/src/ObjectSchema.js
@@ -279,6 +279,24 @@ const ObjectSchema = ({ schema = initialState, ...options } = {}) => {
     },
 
     /**
+     * Returns an object schema with only a subset of keys provided
+     *
+     * @param properties a list of properties you want to keep
+     * @returns {ObjectSchema}
+     */
+    only: properties => {
+      return ObjectSchema({
+        schema: {
+          ...schema,
+          properties: schema.properties.filter(p =>
+            properties.includes(p.name)
+          ),
+        },
+        ...options,
+      })
+    },
+
+    /**
      * The "definitions" keywords provides a standardized location for schema authors to inline re-usable JSON Schemas into a more general schema.
      * There are no restrictions placed on the values within the array.
      *

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -804,6 +804,31 @@ describe('ObjectSchema', () => {
     })
   })
 
+  describe('only', () => {
+    it('returns a subset of the object', () => {
+      const base = S.object()
+        .id('base')
+        .title('base')
+        .prop('foo', S.string())
+        .prop('bar', S.string())
+        .prop('baz', S.string())
+
+      const only = base.only(['foo'])
+
+      expect(only.valueOf()).toEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: 'base',
+        title: 'base',
+        properties: {
+          foo: {
+            type: 'string',
+          },
+        },
+        type: 'object',
+      })
+    })
+  })
+
   describe('raw', () => {
     it('allows to add a custom attribute', () => {
       const schema = ObjectSchema()

--- a/src/ObjectSchema.test.js
+++ b/src/ObjectSchema.test.js
@@ -812,6 +812,12 @@ describe('ObjectSchema', () => {
         .prop('foo', S.string())
         .prop('bar', S.string())
         .prop('baz', S.string())
+        .prop(
+          'children',
+          S.object()
+            .prop('alpha', S.string())
+            .prop('beta', S.string())
+        )
 
       const only = base.only(['foo'])
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -70,6 +70,17 @@ const userSchema = S.object()
 
 console.log('user:\n', JSON.stringify(userSchema.valueOf()))
 
+const largeUserSchema = S.object()
+  .prop('id', S.string().format('uuid'))
+  .prop('username', S.string())
+  .prop('password', S.string())
+  .prop('createdAt', S.string().format('time'))
+  .prop('updatedAt', S.string().format('time'))
+
+const userSubsetSchema = largeUserSchema.only(['username', 'password'])
+
+console.log('user subset:', JSON.stringify(userSubsetSchema.valueOf()))
+
 try {
   S.object().prop('foo', 'boom!' as any)
 } catch (e) {


### PR DESCRIPTION
Implements my idea @ https://github.com/fastify/fluent-schema/issues/84

#### Checklist

- [x] run `npm run test` and `npm run benchmark` (benchmark wasn't defined)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added * will do after review 
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
